### PR TITLE
Add SVD basis, reconstruction, and docs for registration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        julia-version: ['1.6', '1']
+        julia-version: ['1.10', '1']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -18,6 +18,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
   docs:
+    needs: [test]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,38 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        julia-version: ['1.6', '1']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+  docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /Manifest.toml
+docs/Manifest.toml
+docs/build/
 notebooks/*
 notebooks

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,7 @@ version = "0.1.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-LinearAlgebra = "1.6"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,22 +1,13 @@
 name = "SparseSensors"
 uuid = "d6ceb477-1fb8-47dc-9268-a5d33dbc737e"
 authors = ["samtalki <saimouer@gmail.com> and contributors"]
-version = "0.0.1"
+version = "0.1.0"
 
 [deps]
-Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
-SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 
 [compat]
-Convex = "0.14"
-DataFrames = "1"
-Gadfly = "1"
-Revise = "3"
-SCS = "0.7, 0.8"
+LinearAlgebra = "1.6"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 julia = "1.10"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Random", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,93 +1,67 @@
 # SparseSensors.jl
-   
-   This repository is an implementation of the core sparse sensor placement with QR factorization and cost-constrained QR factorization algorithms from Manohar, _et al.,_ "Data-Driven Sparse Sensor Placcement for Reconstruction", and other papers, in Julia. This is a hobbyist port of the fantastic Python library [pysensors](https://github.com/dynamicslab/pysensors) in Julia. 
-   
-   All collaborations and contributions are welcome.
-   
-   
-   
-   ## Installation
-   To install, use Pkg. From the Julia REPL, press ] to enter Pkg-mode and run
-   ```julia
-   pkg> add SparseSensors
-   ```
-   
-   ## Example
-   
-   ```julia
-   using SparseSensors
-   using LinearAlgebra
-   using Gadfly
-   using DataFrames
-   
-   #Setup the experiment
-   r = 11; # Number of basis modes
-   n = 1000;
-   x = collect(0.0:1/n:1.0);
-   vde_basis = VandermondeBasis(x,r);
-   Ψ = vde_basis.Ψ; #Get the vandermonde basis matrix from the Basis struct
-   
-   #Make design matrix
-   X = copy(transpose(Ψ));
-   n_samples,n_features = size(X);
-   
-   #Setup QR pivot sensor placement algorithm
-   qr_pivot = QRPivot(X);
-   fit(qr_pivot);
-   pivots = qr_pivot.pivots;
-   
-   #Select the top 15 sensor locations
-   f = abs.(x.^2 .- 0.5);
-   selected_sensors = get_sensors(pivots,15);
-   x_sensed = x[selected_sensors];
-   y_sensed = f[selected_sensors];
-   
-   #Ground truth
-   df_true = DataFrame();
-   df_true[!,"x_true"] = x
-   df_true[!,"y_true"] = f
-   
-   #Sensed
-   df = DataFrame()
-   df[!,"x_sensed"] = x_sensed;
-   df[!,"y_sensed"] = y_sensed;
-   
-   #Plot the results
-   p1 = plot(df,
-       layer(x=:x_sensed,y=:y_sensed,color=["Optimized Sensors"]),
-       layer(df_true,x=:x_true,y=:y_true,Geom.line,Geom.point,color=["True Function"]),
-       Guide.xlabel("x"),Guide.ylabel("y"))
-   ```
-   
-   ![](example.svg)
-   
-   
-   ## Dependencies
-   
-   julia >v1.6.
-   LinearAlgebra, Gadfly and DataFrames for plotting.
-   
-   ## Todo:
-   
-   - Implement high level SSPOR and SSPOC interfaces
-   - Implement high level basis representation wrapper for SVD, etc.
-   - Set up compatibility with JuliaML/MLJ.jl/ScikitLearn.jl
-   
-   References
-   ------------
-   
-   -  Manohar, Krithika, Bingni W. Brunton, J. Nathan Kutz, and Steven L. Brunton.
-      "Data-driven sparse sensor placement for reconstruction: Demonstrating the
-      benefits of exploiting known patterns."
-      IEEE Control Systems Magazine 38, no. 3 (2018): 63-86.
-      `[DOI] <https://doi.org/10.1109/MCS.2018.2810460>`
-   
-   -  Clark, Emily, Travis Askham, Steven L. Brunton, and J. Nathan Kutz.
-      "Greedy sensor placement with cost constraints." IEEE Sensors Journal 19, no. 7
-      (2018): 2642-2656.
-      `[DOI] <https://doi.org/10.1109/JSEN.2018.2887044>`
-   
-   -  de Silva, Brian M., Krithika Manohar, Emily Clark, Bingni W. Brunton,
-      Steven L. Brunton, J. Nathan Kutz.
-      "PySensors: A Python package for sparse sensor placement."
-      arXiv preprint arXiv:2102.13476 (2021). `[arXiv] <https://arxiv.org/abs/2102.13476>`
+
+[![CI](https://github.com/samtalki/SparseSensors.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/samtalki/SparseSensors.jl/actions/workflows/CI.yml)
+[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://samtalki.github.io/SparseSensors.jl/dev/)
+
+Data-driven sparse sensor placement for reconstruction, implementing the core algorithms from Manohar, *et al.*, "Data-Driven Sparse Sensor Placement for Reconstruction" in Julia. This is a hobbyist attempt to provide a faithful implementation of the fantastic [pysensors](https://github.com/dynamicslab/pysensors) library in Julia.
+
+All collaborations and contributions are welcome.
+
+## Installation
+To install, use Pkg. From the Julia REPL, press `]` to enter Pkg-mode and run
+```julia
+pkg> add SparseSensors
+```
+
+## Example
+
+```julia
+using SparseSensors
+using LinearAlgebra
+
+# Build an SVD basis from snapshot data
+X = randn(200, 50)              # 200 spatial points, 50 snapshots
+basis = SVDBasis(X, 10)         # keep 10 modes
+
+# Find optimal sensor locations
+qr_pivot = QRPivot(basis.Ψ')
+fit(qr_pivot)
+sensors = get_sensors(qr_pivot, 10)
+
+# Reconstruct a new observation from sparse measurements
+x_new = X[:, 1]                 # test signal
+y = x_new[sensors]              # measure at sensor locations
+x̂ = reconstruct(basis, sensors, y)
+```
+
+A Vandermonde (polynomial) basis is also available:
+
+```julia
+x = collect(0.0:0.01:1.0)
+basis = VandermondeBasis(x, 5)
+qr_pivot = QRPivot(basis.Ψ')
+fit(qr_pivot)
+sensors = get_sensors(qr_pivot, 5)
+
+f = @. 2.0 + 3.0*x - x^2       # true signal
+y = f[sensors]
+x̂ = reconstruct(basis, sensors, y)
+```
+
+## References
+
+- Manohar, Krithika, Bingni W. Brunton, J. Nathan Kutz, and Steven L. Brunton.
+  "Data-driven sparse sensor placement for reconstruction: Demonstrating the
+  benefits of exploiting known patterns."
+  IEEE Control Systems Magazine 38, no. 3 (2018): 63-86.
+  [DOI](https://doi.org/10.1109/MCS.2018.2810460)
+
+- Clark, Emily, Travis Askham, Steven L. Brunton, and J. Nathan Kutz.
+  "Greedy sensor placement with cost constraints." IEEE Sensors Journal 19, no. 7
+  (2018): 2642-2656.
+  [DOI](https://doi.org/10.1109/JSEN.2018.2887044)
+
+- de Silva, Brian M., Krithika Manohar, Emily Clark, Bingni W. Brunton,
+  Steven L. Brunton, J. Nathan Kutz.
+  "PySensors: A Python package for sparse sensor placement."
+  arXiv preprint arXiv:2102.13476 (2021). [arXiv](https://arxiv.org/abs/2102.13476)

--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ x̂ = reconstruct(basis, sensors, y)
 - de Silva, Brian M., Krithika Manohar, Emily Clark, Bingni W. Brunton,
   Steven L. Brunton, J. Nathan Kutz.
   "PySensors: A Python package for sparse sensor placement."
-  arXiv preprint arXiv:2102.13476 (2021). [arXiv](https://arxiv.org/abs/2102.13476)
+  Journal of Open Source Software 6, no. 58 (2021): 2828.
+  [DOI](https://doi.org/10.21105/joss.02828)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SparseSensors = "d6ceb477-1fb8-47dc-9268-a5d33dbc737e"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,15 @@
+using Documenter
+using SparseSensors
+
+makedocs(
+    sitename = "SparseSensors.jl",
+    modules = [SparseSensors],
+    pages = [
+        "Home" => "index.md",
+    ],
+)
+
+deploydocs(
+    repo = "github.com/samtalki/SparseSensors.jl.git",
+    devbranch = "main",
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,61 @@
+# SparseSensors.jl
+
+Data-driven sparse sensor placement for reconstruction, based on
+[Manohar et al. (2018)](https://doi.org/10.1109/MCS.2018.2810460).
+
+## Overview
+
+SparseSensors.jl finds optimal sensor locations from a basis (SVD/POD modes or
+Vandermonde polynomials) using column-pivoted QR factorization, then reconstructs
+full-state fields from the sparse measurements.
+
+## Quick Start
+
+```julia
+using SparseSensors, LinearAlgebra
+
+# Build an SVD basis from snapshot data
+X = load_your_data()          # (n_spatial, n_snapshots)
+basis = SVDBasis(X, 10)       # keep 10 modes
+
+# Find optimal sensor locations
+qr_pivot = QRPivot(basis.Ψ')
+fit(qr_pivot)
+sensors = get_sensors(qr_pivot, 10)
+
+# Reconstruct a new observation from sparse measurements
+y = new_observation[sensors]
+x̂ = reconstruct(basis, sensors, y)
+```
+
+## API Reference
+
+### Basis Construction
+
+```@docs
+Basis
+SVDBasis
+VandermondeBasis
+```
+
+### Sensor Placement
+
+```@docs
+QRPivot
+CostQRPivot
+fit
+get_sensors
+```
+
+### Reconstruction
+
+```@docs
+reconstruct
+```
+
+### Internal
+
+```@docs
+SparseSensors.make_helper_variables
+SparseSensors.qr_reflector
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,6 +2,9 @@
 
 Data-driven sparse sensor placement for reconstruction, based on
 [Manohar et al. (2018)](https://doi.org/10.1109/MCS.2018.2810460).
+This package provides a Julia implementation inspired by
+[pysensors](https://github.com/dynamicslab/pysensors)
+([de Silva et al., 2021](https://doi.org/10.21105/joss.02828)).
 
 ## Overview
 

--- a/examples/simple_qr_example.jl
+++ b/examples/simple_qr_example.jl
@@ -1,46 +1,27 @@
 using SparseSensors
 using LinearAlgebra
-using Gadfly
-using DataFrames
 
-#Setup the experiment
-r = 11; # Number of basis modes
-n = 1000;
-x = collect(0.0:1/n:1.0);
-vde_basis = VandermondeBasis(x,r);
-Ψ = vde_basis.Ψ; #Get the vandermonde basis matrix from the Basis struct
+# Setup the experiment
+r = 11  # Number of basis modes
+n = 1000
+x = collect(0.0:1/n:1.0)
+basis = VandermondeBasis(x, r)
 
-#Make design matrix
-X = copy(transpose(Ψ));
-n_samples,n_features = size(X);
+# Setup QR pivot sensor placement algorithm
+qr_pivot = QRPivot(basis.Ψ')
+fit(qr_pivot)
 
-#Setup QR pivot sensor placement algorithm
-qr_pivot = QRPivot(X);
-fit(qr_pivot);
-pivots = qr_pivot.pivots;
+# Select the top 15 sensor locations
+f = abs.(x .^ 2 .- 0.5)
+selected_sensors = get_sensors(qr_pivot, 15)
+x_sensed = x[selected_sensors]
+y_sensed = f[selected_sensors]
 
-#Select the top 15 sensor locations
-f = abs.(x.^2 .- 0.5);
-selected_sensors = get_sensors(pivots,15);
-x_sensed = x[selected_sensors];
-y_sensed = f[selected_sensors];
+println("Top 15 sensor locations (indices): ", selected_sensors)
+println("Sensor x-coordinates: ", round.(x_sensed, digits=4))
+println("Sensor measurements:  ", round.(y_sensed, digits=4))
 
-#Ground truth
-df_true = DataFrame();
-df_true[!,"x_true"] = x
-df_true[!,"y_true"] = f
-
-#Sensed
-df = DataFrame()
-df[!,"x_sensed"] = x_sensed;
-df[!,"y_sensed"] = y_sensed;
-
-#Plot the results
-p1 = plot(df,
-    layer(x=:x_sensed,y=:y_sensed,color=["Optimized Sensors"]),
-    layer(df_true,x=:x_true,y=:y_true,Geom.line,Geom.point,color=["True Function"]),
-    Guide.xlabel("x"),Guide.ylabel("y"),
-    Theme(background_color=colorant"white"))
-
-#Save image
-draw(SVG("example.svg",7inch,3.326inch),p1)
+# Reconstruct the signal from sensor measurements
+x̂ = reconstruct(basis, selected_sensors, f[selected_sensors])
+max_error = maximum(abs.(x̂ .- f))
+println("Max reconstruction error: ", max_error)

--- a/src/SparseSensors.jl
+++ b/src/SparseSensors.jl
@@ -1,19 +1,31 @@
 module SparseSensors
 using LinearAlgebra
+
+"""
+    AbstractSampler
+
+Abstract supertype for all sensor placement samplers.
+
+Concrete subtypes ([`QRPivot`](@ref), [`CostQRPivot`](@ref)) must provide a
+`pivots::Vector{Int}` field and a [`fit`](@ref) method.
+"""
+abstract type AbstractSampler end
+
 include("qr.jl")
 include("ccqr.jl")
 include("basis.jl")
 include("reconstruct.jl")
 
+export AbstractSampler
 export QRPivot, CostQRPivot, fit, VandermondeBasis, SVDBasis, Basis
 export get_sensors, reconstruct
 
 """
-    get_sensors(sampler) -> Vector{Int}
+    get_sensors(sampler::AbstractSampler) -> Vector{Int}
 
-Return all ranked sensor locations from a fitted [`QRPivot`](@ref) or [`CostQRPivot`](@ref).
+Return all ranked sensor locations from a fitted [`AbstractSampler`](@ref).
 """
-function get_sensors(sampler)
+function get_sensors(sampler::AbstractSampler)
     return sampler.pivots
 end
 
@@ -27,11 +39,11 @@ function get_sensors(pivots::AbstractArray, n_sensors::Int)
 end
 
 """
-    get_sensors(sampler, n_sensors) -> Vector{Int}
+    get_sensors(sampler::AbstractSampler, n_sensors) -> Vector{Int}
 
-Return the top `n_sensors` locations from a fitted sampler.
+Return the top `n_sensors` locations from a fitted [`AbstractSampler`](@ref).
 """
-function get_sensors(sampler, n_sensors)
+function get_sensors(sampler::AbstractSampler, n_sensors)
     return get_sensors(sampler.pivots, n_sensors)
 end
 end

--- a/src/SparseSensors.jl
+++ b/src/SparseSensors.jl
@@ -1,26 +1,37 @@
 module SparseSensors
-using LinearAlgebra: Matrix, conj
-greet() = print("Hello World!")
 using LinearAlgebra
 include("qr.jl")
 include("ccqr.jl")
 include("basis.jl")
 include("reconstruct.jl")
 
-export QRPivot,CostQRPivot,fit,VandermondeBasis
+export QRPivot, CostQRPivot, fit, VandermondeBasis, SVDBasis, Basis
+export get_sensors, reconstruct
 
-export get_sensors
+"""
+    get_sensors(sampler) -> Vector{Int}
 
+Return all ranked sensor locations from a fitted [`QRPivot`](@ref) or [`CostQRPivot`](@ref).
+"""
 function get_sensors(sampler)
     return sampler.pivots
 end
 
-function get_sensors(pivots::AbstractArray,n_sensors::Int)
+"""
+    get_sensors(pivots::AbstractArray, n_sensors::Int) -> Vector{Int}
+
+Return the top `n_sensors` locations from a pivot vector.
+"""
+function get_sensors(pivots::AbstractArray, n_sensors::Int)
     return pivots[1:n_sensors]
 end
 
-function get_sensors(sampler,n_sensors)
-    return sampler.pivots[1:n_sensors]
-end
-end
+"""
+    get_sensors(sampler, n_sensors) -> Vector{Int}
 
+Return the top `n_sensors` locations from a fitted sampler.
+"""
+function get_sensors(sampler, n_sensors)
+    return get_sensors(sampler.pivots, n_sensors)
+end
+end

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -1,25 +1,72 @@
+"""
+    Basis(Ψ, r)
+
+A truncated basis representation for sparse sensor placement.
+
+# Fields
+- `Ψ::Matrix`: Basis matrix of size `(n, r)` where `n` is the number of spatial locations
+  and `r` is the number of retained modes.
+- `r::Int`: Number of retained modes (columns of `Ψ`).
+"""
 struct Basis
     Ψ::Matrix
     r::Int
 end
 
-function VandermondeBasis(x,r::Int;verbose::Bool=false)
-    """Makes a vandermonde basis given a range and a number of basis modes"""
-    Ψ = zeros((length(x),r))
-    for (j,col) in enumerate(eachcol(Ψ))
-        ψ = make_vander_column(j,x)
-        if verbose
-            println("ψ","_"*string(j)," size: ",size(ψ))
-        end
-        Ψ[:,j] = make_vander_column(j,x) #Each col is x^(k-1)
+"""
+    VandermondeBasis(x, r::Int) -> Basis
+
+Construct a [`Basis`](@ref) from a Vandermonde matrix. Column `j` is `x.^(j-1)`.
+
+# Arguments
+- `x`: Vector of evaluation points.
+- `r::Int`: Number of basis modes (polynomial degree + 1).
+
+# Examples
+```julia
+basis = VandermondeBasis(0.0:0.1:1.0, 3)
+basis.Ψ[:, 1]  # all ones
+basis.Ψ[:, 2]  # x values
+basis.Ψ[:, 3]  # x² values
+```
+"""
+function VandermondeBasis(x, r::Int)
+    Ψ = zeros((length(x), r))
+    for j in 1:r
+        Ψ[:, j] = make_vander_column(j, x)
     end
-    if verbose
-        print("Final Ψ size: ",size(Ψ))
-    end
-    return Basis(Ψ,r) #Truncated basis matrix
+    return Basis(Ψ, r)
 end
 
-function make_vander_column(k,col_k)
+"""
+    SVDBasis(X::AbstractMatrix, r::Int) -> Basis
+
+Construct a [`Basis`](@ref) from the first `r` left singular vectors of a data matrix `X`.
+
+This is the primary basis in the sparse sensor placement literature
+(Manohar et al., 2018). Each column of `X` is a snapshot; the returned basis
+captures the dominant `r` spatial modes.
+
+# Arguments
+- `X::AbstractMatrix`: Data matrix of size `(n, m)` where `n` is the number of spatial
+  locations and `m` is the number of snapshots.
+- `r::Int`: Number of modes to retain (`r ≤ min(n, m)`).
+
+# Examples
+```julia
+X = randn(100, 50)   # 100 spatial points, 50 snapshots
+basis = SVDBasis(X, 5)
+size(basis.Ψ)         # (100, 5)
+```
+"""
+function SVDBasis(X::AbstractMatrix, r::Int)
+    n, m = size(X)
+    r ≤ min(n, m) || throw(ArgumentError("r=$r exceeds min(size(X)) = $(min(n, m))"))
+    U, _, _ = svd(X)
+    return Basis(U[:, 1:r], r)
+end
+
+function make_vander_column(k, col_k)
     ψ = [x^(k-1) for x in col_k]
-    return ψ #Column of basis matrix
+    return ψ
 end

--- a/src/ccqr.jl
+++ b/src/ccqr.jl
@@ -13,7 +13,7 @@ Sensors with high cost are pushed later in the pivot ordering.
 
 See also: [`QRPivot`](@ref), [`fit`](@ref)
 """
-mutable struct CostQRPivot
+mutable struct CostQRPivot <: AbstractSampler
     Ψ::AbstractArray
     pivots::Vector{Int}
     sensor_costs::AbstractVector

--- a/src/ccqr.jl
+++ b/src/ccqr.jl
@@ -1,64 +1,94 @@
-### 
-# Const-constrained QR optimizer for sensor placement.
-###
+"""
+    CostQRPivot(Ψ, pivots, sensor_costs)
 
+Cost-constrained QR sensor placement optimizer.
+
+Extends QR-pivoted sensor placement by penalizing expensive sensor locations.
+Sensors with high cost are pushed later in the pivot ordering.
+
+# Fields
+- `Ψ::AbstractArray`: Basis matrix (modes × sensors).
+- `pivots::Vector{Int}`: Ranked sensor locations (populated by [`fit`](@ref)).
+- `sensor_costs::AbstractVector`: Per-sensor cost vector (length must equal number of columns).
+
+See also: [`QRPivot`](@ref), [`fit`](@ref)
+"""
 mutable struct CostQRPivot
     Ψ::AbstractArray
-    pivots::AbstractArray
-    sensor_costs::AbstractArray #Costs/weights associated with each sensor. Postsive is bad, negative good.
+    pivots::Vector{Int}
+    sensor_costs::AbstractVector
 end
 
-function CostQRPivot(qrpivot::QRPivot,sensor_costs::Vector{Float64})
-    return CostQRPivot(qrpivot.Ψ,qrpivot.pivots,sensor_costs)
+function CostQRPivot(qrpivot::QRPivot, sensor_costs::AbstractVector)
+    return CostQRPivot(qrpivot.Ψ, Int[], sensor_costs)
 end
 
-function CostQRPivot(Ψ::AbstractArray,pivots::Vector,sensor_costs::Vector{Float64})
-    return CostQRPivot(Ψ,pivots,sensor_costs)
-end
+"""
+    fit(cost_qr_pivot::CostQRPivot) -> CostQRPivot
 
+Compute cost-constrained sensor locations. Works like [`fit(::QRPivot)`](@ref) but
+subtracts `sensor_costs` from column norms at each pivot step, preferring cheaper sensors
+when information content is similar.
+
+Throws `DomainError` if the length of `sensor_costs` does not match the number of columns.
+"""
 function fit(cost_qr_pivot::CostQRPivot)
-    n,m = size(cost_qr_pivot.Ψ)
+    n, m = size(cost_qr_pivot.Ψ)
 
-    if cost_qr_pivot.sensor_costs !== n
-        throw(DomainError(cost_qr_pivot.sensor_costs,"The specified sensor costs are inconsistent with the basis dimensions"))
+    if length(cost_qr_pivot.sensor_costs) != m
+        throw(DomainError(cost_qr_pivot.sensor_costs, "Sensor costs length must match number of columns (sensors)"))
     end
-    #Initialize helper variables
-    R,p,k = make_helper_variables(cost_qr_pivot.Ψ)
+
+    R, p, k = make_helper_variables(cost_qr_pivot.Ψ)
 
     for j in 1:k
-        u,i_piv = qr_reflector(R[j:n,j:m],cost_qr_pivot.sensor_costs)
-        #Track column pivots
-        i_piv += j 
-        p[[j,i_piv]] = p[[i_piv,j]]
-        #Switch column
-        R[:,[j,i_piv]] = R[:,[i_piv,j]] 
-        #Apply reflector
-        R[j:n,j:m] -= outer(u,dot(u,R[j:n,j:m]))
-        R[j+1:n,j] = 0
+        Rsub = @view R[j:n, j:m]
+        u, i_piv = qr_reflector(Rsub, cost_qr_pivot.sensor_costs[p[j:m]])
+        i_piv += j - 1
+        p[[j, i_piv]] = p[[i_piv, j]]
+        R[:, [j, i_piv]] = R[:, [i_piv, j]]
+        Rsub .-= u * (u' * Rsub)
+        R[j+1:n, j] .= 0
     end
     cost_qr_pivot.pivots = p
+    return cost_qr_pivot
 end
 
+"""
+    make_helper_variables(Ψ) -> (R, p, k)
+
+Initialize working variables for cost-constrained QR factorization.
+
+Returns the conjugate copy `R`, the identity permutation `p`, and the pivot count `k`.
+"""
 function make_helper_variables(Ψ)
-    """Constructs the reflector helper variables"""
-    R = conj(Ψ)
-    p = [i for i in 1:n]
-    k = min(m,n)
-    return R,p,k
+    R = float.(conj(Ψ))
+    n, m = size(Ψ)
+    p = collect(1:m)
+    k = min(m, n)
+    return R, p, k
 end
 
-function qr_reflector(r,costs)
-    dlens = sqrt(sum(abs(eachrow(r))^2)) #Norm of each column
-    i_piv = argmax(dlens-costs) # choose pivot
+"""
+    qr_reflector(r, costs) -> (u, i_piv)
+
+Compute a Householder reflector for cost-constrained column pivoting.
+
+Selects the pivot column that maximises `‖column‖ − cost`, then returns the
+Householder vector `u` and the pivot index `i_piv`.
+"""
+function qr_reflector(r, costs)
+    dlens = [norm(c) for c in eachcol(r)]
+    i_piv = argmax(dlens - costs)
     dlen = dlens[i_piv]
 
-    if dlen > 0 
-        u = r[:,i_piv]/dlen
-        u[1] += sign(u[1])+(u[1]==0)
-        u/=sqrt(abs(u[1]))
+    if dlen > 0
+        u = r[:, i_piv] / dlen
+        u[1] += sign(u[1]) + (u[1] == 0)
+        u /= sqrt(abs(u[1]))
     else
-        u = r[:,i_piv]
+        u = r[:, i_piv]
         u[1] = sqrt(2)
     end
-    return u,i_piv
+    return u, i_piv
 end

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -1,43 +1,34 @@
-###
-# Standard QR Pivot Optimizer
-###
+"""
+    QRPivot(Ψ)
 
+Optimal sensor placement via QR factorization with column pivoting.
+
+# Fields
+- `Ψ::AbstractArray`: Basis matrix (typically modes × sensors)
+- `pivots::Vector{Int}`: Ranked sensor locations (populated by [`fit`](@ref))
+"""
 mutable struct QRPivot
-	Ψ::AbstractArray #Basis matrix from SVD, RPCA, etc.
-	pivots::AbstractArray #Ranked list of sensor locations
+	Ψ::AbstractArray
+	pivots::Vector{Int}
 end
 
 function QRPivot(Ψ)
-	n,m = size(Ψ)
-	pivots = zeros((max(n,m),1))
-	return QRPivot(Ψ,pivots)
+	return QRPivot(Ψ, Int[])
 end
 
-function QRPivot(Ψ,n_sensors::Int)
-	n,m = size(Ψ)
-	pivots = zeros((n_sensors,1))
-	return QRPivot(Ψ,pivots)
-end
+"""
+    fit(qr_pivot::QRPivot) -> QRPivot
 
-function QRPivot(Ψ,pivots::AbstractArray)
-	return QRPivot(Ψ,pivots)
-end
-
-function fit(qr_pivot::QRPivot;optimizer_kwargs...)
-	"""
-	Fits the QRPivot sensor placement.
-	qrpivot::QRPivot
-		QRPivot object.
-	optimizer_kwargs: dictionary
-		Optional settings for optimizer
-	"""
+Compute optimal sensor locations for the given [`QRPivot`](@ref) using column-pivoted QR
+factorization. The resulting pivot indices are stored in `qr_pivot.pivots`, ordered from
+most to least informative.
+"""
+function fit(qr_pivot::QRPivot)
 	qr_pivot.pivots = sensor_placement(qr_pivot.Ψ)
+	return qr_pivot
 end
 
 function sensor_placement(Ψ)
-	# --> Compute the QRPivot w/ column pivoting decomposition of Ψ.
-	_, _, p = qr(conj(Ψ), Val(true))
+	_, _, p = qr(conj(Ψ), ColumnNorm())
 	return p[1:size(Ψ, 2)]
 end
-
-

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -7,7 +7,7 @@ Optimal sensor placement via QR factorization with column pivoting.
 - `Ψ::AbstractArray`: Basis matrix (typically modes × sensors)
 - `pivots::Vector{Int}`: Ranked sensor locations (populated by [`fit`](@ref))
 """
-mutable struct QRPivot
+mutable struct QRPivot <: AbstractSampler
 	Ψ::AbstractArray
 	pivots::Vector{Int}
 end

--- a/src/reconstruct.jl
+++ b/src/reconstruct.jl
@@ -34,9 +34,11 @@ end
 Convenience method that extracts sensor indices from `sampler.pivots` (a fitted
 [`QRPivot`](@ref) or [`CostQRPivot`](@ref)) and reconstructs the full state.
 
-The number of sensors used equals the number of basis modes (`basis.r`).
+The number of sensors used is determined by `length(measurements)`, so
+overdetermined reconstruction (more sensors than basis modes) is supported.
 """
 function reconstruct(sampler, basis::Basis, measurements::AbstractVector)
-    sensor_indices = sampler.pivots[1:basis.r]
+    n_sensors = length(measurements)
+    sensor_indices = sampler.pivots[1:n_sensors]
     return reconstruct(basis, sensor_indices, measurements)
 end

--- a/src/reconstruct.jl
+++ b/src/reconstruct.jl
@@ -39,6 +39,11 @@ overdetermined reconstruction (more sensors than basis modes) is supported.
 """
 function reconstruct(sampler, basis::Basis, measurements::AbstractVector)
     n_sensors = length(measurements)
+    if length(sampler.pivots) < n_sensors
+        throw(ArgumentError(
+            "sampler has $(length(sampler.pivots)) pivots but $n_sensors measurements were provided; " *
+            "call fit(sampler) before reconstruct"))
+    end
     sensor_indices = sampler.pivots[1:n_sensors]
     return reconstruct(basis, sensor_indices, measurements)
 end

--- a/src/reconstruct.jl
+++ b/src/reconstruct.jl
@@ -1,45 +1,42 @@
-using Convex,SCS
+"""
+    reconstruct(basis::Basis, sensor_indices::AbstractVector{Int}, measurements::AbstractVector)
 
-mutable struct SSPOR
-    basis::Basis
-    selected_sensors::Vector
-    n_sensors::Int
-    n_basis_modes::Int
-    fit_::Function
-    predict_::Function
-    optimizer
+Reconstruct the full state from sparse sensor measurements.
+
+Solves the linear system `Ψ[sensor_indices, :] * a = measurements` for the
+mode coefficients `a`, then returns the full-field estimate `Ψ * a`.
+
+# Arguments
+- `basis::Basis`: The basis used for sensor placement.
+- `sensor_indices::AbstractVector{Int}`: Indices of the sensor locations.
+- `measurements::AbstractVector`: Measured values at those locations.
+
+# Returns
+- `Vector`: Reconstructed full-state vector of length `size(basis.Ψ, 1)`.
+
+# Examples
+```julia
+basis = VandermondeBasis(0.0:0.01:1.0, 5)
+sensors = [1, 26, 51, 76, 101]
+y = f.(x[sensors])          # measure at sensor locations
+x̂ = reconstruct(basis, sensors, y)
+```
+"""
+function reconstruct(basis::Basis, sensor_indices::AbstractVector{Int}, measurements::AbstractVector)
+    Θ = basis.Ψ[sensor_indices, :]
+    a = Θ \ measurements
+    return basis.Ψ * a
 end
 
-struct Reconstructor
-    fit::Function
-    predict::Function
+"""
+    reconstruct(sampler, basis::Basis, measurements::AbstractVector)
+
+Convenience method that extracts sensor indices from `sampler.pivots` (a fitted
+[`QRPivot`](@ref) or [`CostQRPivot`](@ref)) and reconstructs the full state.
+
+The number of sensors used equals the number of basis modes (`basis.r`).
+"""
+function reconstruct(sampler, basis::Basis, measurements::AbstractVector)
+    sensor_indices = sampler.pivots[1:basis.r]
+    return reconstruct(basis, sensor_indices, measurements)
 end
-
-# function fit(model::SSPOR;quiet=true)
-#     if model.fit_ === fit_lsq
-#         model.fit_()
-#     end
-# end
-
-# function predict(model::SSPOR,x::Vector;quiet=true)
-#     if model.predict_ === predict_lsq
-#         model.predict_(model.Ψ,x,model.n_basis_modes)
-#     end
-
-# end
-
-function fit_lsq(Ψ,x,y,selected_sensors)
-    y_sensed = y[selected_sensors];
-    x_sensed = x[selected_sensors];
-    Ψ_sensed = Ψ[:,selected_sensors]
-    return Ψ_sensed,x_sensed,y_sensed
-end
-
-function predict_lsq(Ψ,x,y,n_basis_modes)
-    X = Convex.Variable(size(x))    
-    prob = minimize(sumsquares(y-Ψ*X))
-    solve!(prob,()-> SCS.Optimizer(verbose=false))
-    prob.status
-    return prob.optval
-end
-

--- a/src/reconstruct.jl
+++ b/src/reconstruct.jl
@@ -29,15 +29,15 @@ function reconstruct(basis::Basis, sensor_indices::AbstractVector{Int}, measurem
 end
 
 """
-    reconstruct(sampler, basis::Basis, measurements::AbstractVector)
+    reconstruct(sampler::AbstractSampler, basis::Basis, measurements::AbstractVector)
 
-Convenience method that extracts sensor indices from `sampler.pivots` (a fitted
-[`QRPivot`](@ref) or [`CostQRPivot`](@ref)) and reconstructs the full state.
+Convenience method that extracts sensor indices from a fitted [`AbstractSampler`](@ref)
+and reconstructs the full state.
 
 The number of sensors used is determined by `length(measurements)`, so
 overdetermined reconstruction (more sensors than basis modes) is supported.
 """
-function reconstruct(sampler, basis::Basis, measurements::AbstractVector)
+function reconstruct(sampler::AbstractSampler, basis::Basis, measurements::AbstractVector)
     n_sensors = length(measurements)
     if length(sampler.pivots) < n_sensors
         throw(ArgumentError(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SparseSensors
 using LinearAlgebra
 using Test
+using Random
 
 @testset "SparseSensors.jl" begin
 
@@ -15,6 +16,7 @@ using Test
     end
 
     @testset "SVDBasis" begin
+        Random.seed!(42)
         n, m, r = 50, 30, 5
         # Build a rank-r matrix so the first r singular vectors are well-defined
         A = randn(n, r)
@@ -134,6 +136,7 @@ using Test
     end
 
     @testset "SVDBasis + reconstruct" begin
+        Random.seed!(42)
         # Build synthetic data from known modes, place sensors, reconstruct
         n = 100
         t = range(0, 2π, length=n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,7 +73,7 @@ using Test
         Ψ = copy(transpose(basis.Ψ))
         n_sensors = size(Ψ, 2)
 
-        # Uniform costs → valid permutation
+        # Uniform zero costs → same result as unconstrained QRPivot
         costs = zeros(n_sensors)
         qr_pivot = QRPivot(Ψ)
         fit(qr_pivot)
@@ -81,6 +81,7 @@ using Test
         fit(ccqr)
         @test length(ccqr.pivots) == n_sensors
         @test sort(ccqr.pivots) == collect(1:n_sensors)
+        @test ccqr.pivots == qr_pivot.pivots
 
         # High cost on sensor 1 pushes it out of first pivot
         costs_high = zeros(n_sensors)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,152 @@
 using SparseSensors
+using LinearAlgebra
 using Test
 
 @testset "SparseSensors.jl" begin
-    # Write your tests here.
+
+    @testset "VandermondeBasis" begin
+        x = collect(0.0:0.1:1.0)
+        r = 3
+        basis = VandermondeBasis(x, r)
+        @test size(basis.Ψ) == (length(x), r)
+        @test all(basis.Ψ[:, 1] .≈ 1.0)
+        @test basis.Ψ[:, 2] ≈ x
+        @test basis.Ψ[:, 3] ≈ x .^ 2
+    end
+
+    @testset "SVDBasis" begin
+        n, m, r = 50, 30, 5
+        # Build a rank-r matrix so the first r singular vectors are well-defined
+        A = randn(n, r)
+        B = randn(r, m)
+        X = A * B
+
+        basis = SVDBasis(X, r)
+        @test size(basis.Ψ) == (n, r)
+        @test basis.r == r
+
+        # Columns should be orthonormal
+        @test basis.Ψ' * basis.Ψ ≈ I(r) atol=1e-10
+
+        # The r modes should capture (nearly) all variance of the rank-r matrix
+        U_full, S, _ = svd(X)
+        captured = sum(S[1:r].^2) / sum(S.^2)
+        @test captured ≈ 1.0 atol=1e-10
+    end
+
+    @testset "QRPivot" begin
+        x = collect(0.0:0.01:1.0)
+        r = 5
+        basis = VandermondeBasis(x, r)
+        Ψ = copy(transpose(basis.Ψ))
+        qr_pivot = QRPivot(Ψ)
+        fit(qr_pivot)
+        pivots = qr_pivot.pivots
+        n = size(Ψ, 2)
+        @test length(pivots) == n
+        @test sort(pivots) == collect(1:n)
+    end
+
+    @testset "get_sensors" begin
+        x = collect(0.0:0.01:1.0)
+        r = 5
+        basis = VandermondeBasis(x, r)
+        Ψ = copy(transpose(basis.Ψ))
+        qr_pivot = QRPivot(Ψ)
+        fit(qr_pivot)
+
+        all_sensors = get_sensors(qr_pivot)
+        @test length(all_sensors) == size(Ψ, 2)
+
+        top5 = get_sensors(qr_pivot, 5)
+        @test length(top5) == 5
+
+        top3_from_pivots = get_sensors(qr_pivot.pivots, 3)
+        @test length(top3_from_pivots) == 3
+        @test top3_from_pivots == qr_pivot.pivots[1:3]
+    end
+
+    @testset "CostQRPivot" begin
+        x = collect(0.0:0.01:1.0)
+        r = 5
+        basis = VandermondeBasis(x, r)
+        Ψ = copy(transpose(basis.Ψ))
+        n_sensors = size(Ψ, 2)
+
+        # Uniform costs → valid permutation
+        costs = zeros(n_sensors)
+        qr_pivot = QRPivot(Ψ)
+        fit(qr_pivot)
+        ccqr = CostQRPivot(qr_pivot, costs)
+        fit(ccqr)
+        @test length(ccqr.pivots) == n_sensors
+        @test sort(ccqr.pivots) == collect(1:n_sensors)
+
+        # High cost on sensor 1 pushes it out of first pivot
+        costs_high = zeros(n_sensors)
+        costs_high[1] = 1e10
+        ccqr2 = CostQRPivot(Ψ, Int[], costs_high)
+        fit(ccqr2)
+        @test ccqr2.pivots[1] != 1
+
+        # Wrong-length costs throws DomainError
+        @test_throws DomainError fit(CostQRPivot(Ψ, Int[], zeros(3)))
+    end
+
+    @testset "reconstruct" begin
+        # Reconstruct a known polynomial from sensor measurements
+        x = collect(0.0:0.01:1.0)
+        n = length(x)
+        r = 4
+
+        # True signal: 2 + 3x - x² + 0.5x³
+        f_true = 2.0 .+ 3.0 .* x .- x .^ 2 .+ 0.5 .* x .^ 3
+
+        basis = VandermondeBasis(x, r)
+        Ψ_T = copy(transpose(basis.Ψ))
+        qr_pivot = QRPivot(Ψ_T)
+        fit(qr_pivot)
+
+        sensors = get_sensors(qr_pivot, r)
+        measurements = f_true[sensors]
+
+        # Reconstruct from explicit sensor indices
+        x̂ = reconstruct(basis, sensors, measurements)
+        @test length(x̂) == n
+        @test x̂ ≈ f_true atol=1e-8
+
+        # Reconstruct via sampler convenience method
+        x̂2 = reconstruct(qr_pivot, basis, measurements)
+        @test x̂2 ≈ f_true atol=1e-8
+    end
+
+    @testset "SVDBasis + reconstruct" begin
+        # Build synthetic data from known modes, place sensors, reconstruct
+        n = 100
+        t = range(0, 2π, length=n)
+
+        # 3 spatial modes
+        mode1 = sin.(t)
+        mode2 = cos.(t)
+        mode3 = sin.(2t)
+
+        # 50 snapshots with known coefficients
+        m = 50
+        coeffs = randn(3, m)
+        X = hcat(mode1, mode2, mode3) * coeffs  # (n, m)
+
+        basis = SVDBasis(X, 3)
+        Ψ_T = copy(transpose(basis.Ψ))
+        qr_pivot = QRPivot(Ψ_T)
+        fit(qr_pivot)
+
+        # Pick a test snapshot and reconstruct
+        test_signal = X[:, 1]
+        sensors = get_sensors(qr_pivot, 3)
+        measurements = test_signal[sensors]
+        x̂ = reconstruct(basis, sensors, measurements)
+
+        @test length(x̂) == n
+        @test x̂ ≈ test_signal atol=1e-8
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,14 @@ using Test
         fit(ccqr2)
         @test ccqr2.pivots[1] != 1
 
+        # Making one sensor cheap (all others expensive) forces it to be selected first
+        costs_cheap = fill(1e10, n_sensors)
+        cheap_idx = 50
+        costs_cheap[cheap_idx] = 0.0
+        ccqr3 = CostQRPivot(Ψ, Int[], costs_cheap)
+        fit(ccqr3)
+        @test ccqr3.pivots[1] == cheap_idx
+
         # Wrong-length costs throws DomainError
         @test_throws DomainError fit(CostQRPivot(Ψ, Int[], zeros(3)))
     end
@@ -119,6 +127,10 @@ using Test
         # Reconstruct via sampler convenience method
         x̂2 = reconstruct(qr_pivot, basis, measurements)
         @test x̂2 ≈ f_true atol=1e-8
+
+        # Unfitted sampler throws ArgumentError
+        unfitted = QRPivot(Ψ_T)
+        @test_throws ArgumentError reconstruct(unfitted, basis, measurements)
     end
 
     @testset "SVDBasis + reconstruct" begin


### PR DESCRIPTION
## Summary
- Add `SVDBasis` for truncated SVD/POD modes — the primary basis in the sparse sensor placement literature (Manohar et al. 2018)
- Add `reconstruct()` for full-field state reconstruction from sparse sensor measurements, with a convenience overload accepting fitted samplers
- Add docstrings to all exported types and functions (`Basis`, `VandermondeBasis`, `SVDBasis`, `QRPivot`, `CostQRPivot`, `fit`, `get_sensors`, `reconstruct`, `make_helper_variables`, `qr_reflector`)
- Set up Documenter.jl with CI deployment (`docs/make.jl`, `docs/Project.toml`, `docs/src/index.md`)
- Add docs deployment job to CI workflow
- Polish README with CI/docs badges and updated SVD + reconstruction example
- Clean up `Project.toml`: remove unused deps (Convex, SCS, Gadfly, DataFrames, Revise), add `LinearAlgebra` compat entry
- Add comprehensive tests for `SVDBasis` (shape, orthonormality, variance capture) and `reconstruct` (polynomial + SVD round-trip)

## Test plan
- [x] `julia -e 'using Pkg; Pkg.activate("."); Pkg.test()'` — all 23 tests pass
- [ ] CI passes on GitHub Actions (Julia 1.6 + latest)
- [ ] Docs build succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)